### PR TITLE
Get the Size Dinamically

### DIFF
--- a/screenInfo.py
+++ b/screenInfo.py
@@ -9,4 +9,4 @@ for monitor in get_monitors:
 
 monitorWidth = width
 monitorHeight = height
-fileSavePath = path
+fileSavePath = path.absolute()

--- a/screenInfo.py
+++ b/screenInfo.py
@@ -1,0 +1,12 @@
+from screeninfo import get_monitors # it uses poetry as a sub package and needs to be installed since it is an external lib
+from pathlib import Path
+
+for monitor in get_monitors:
+    if monitor.is_primary:
+        width = monitor.width
+        height = monitor.height
+        path = Path("C:\\Users\\willi\\Pictures\\APOD Pics\\collage.jpg"")
+
+monitorWidth = width
+monitorHeight = height
+fileSavePath = path

--- a/script.py
+++ b/script.py
@@ -5,12 +5,13 @@ from PIL import Image
 import datetime
 import ctypes
 import json
+from screenInfo import monitorWidth, monitorHeight, fileSavePath
 
-with open("userDefinedVariables.json", "r") as userDefinedVariables:
-  userDefinedVariables = json.load(userDefinedVariables)
-  monitorWidth = userDefinedVariables['MONITOR_WIDTH']
-  monitorHeight = userDefinedVariables['MONITOR_HEIGHT']
-  fileSavePath = userDefinedVariables['FILE_SAVE_PATH']
+#with open("userDefinedVariables.json", "r") as userDefinedVariables:
+#  userDefinedVariables = json.load(userDefinedVariables)
+#  monitorWidth = userDefinedVariables['MONITOR_WIDTH']
+#  monitorHeight = userDefinedVariables['MONITOR_HEIGHT']
+#  fileSavePath = userDefinedVariables['FILE_SAVE_PATH']
 
 today = datetime.datetime.now().strftime("%Y-%m-%d").replace("/", "-")
 eightDaysAgo = (datetime.datetime.now() - datetime.timedelta(days=8)).strftime("%Y-%m-%d").replace("/", "-")


### PR DESCRIPTION
Using 2 modules to make the script smarter
screeninfo, which is an external dependence that works in both, linux and windows, to get the screensize dinamically
I restricted it to get only the main display specification


To the path to save the data, I added it with pathlib, which is a more safe and reliable built in module to work with paths in python